### PR TITLE
package.json: Declare minimum Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "tslint": "^5.5.0",
     "typescript": "^2.4.1"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "jest": {
     "mapCoverage": true,
     "moduleFileExtensions": [


### PR DESCRIPTION
This is not handled as a breaking change because our dependencies already were requiring Node 6+, we just didn't declare it properly yet.