### PR TITLE
Drop support for Node v10 and below

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     name: Tests (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^3.9.7"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
see https://nodejs.org/en/about/releases/ 😉 