### PR TITLE
GeoDatum handling

### DIFF
--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -120,6 +120,9 @@ exports[`IGCParser parse() 1G_77fv6m71.igc 1`] = `
       "valid": true,
     },
   ],
+  "geoDatum": "WGS-1984",
+  "geoDatumAlgorithm": null,
+  "geoPressureAlgorithm": null,
   "gliderType": "ASW 19",
   "hardwareVersion": "23",
   "loggerId": "6M7",
@@ -270,6 +273,9 @@ exports[`IGCParser parse() 654G6NG1.IGC 1`] = `
       "valid": true,
     },
   ],
+  "geoDatum": "WGS84",
+  "geoDatumAlgorithm": null,
+  "geoPressureAlgorithm": null,
   "gliderType": "ASG-29E (18m)",
   "hardwareVersion": "Flarm-IGC06",
   "loggerId": "6NG",
@@ -394,6 +400,9 @@ exports[`IGCParser parse() 2016-11-08-xcs-aaa-02.igc 1`] = `
       "valid": true,
     },
   ],
+  "geoDatum": "WGS-1984",
+  "geoDatumAlgorithm": null,
+  "geoPressureAlgorithm": null,
   "gliderType": "DUO DISCUS",
   "hardwareVersion": null,
   "loggerId": "AAA",
@@ -506,6 +515,9 @@ exports[`IGCParser parse() 20180427.igc 1`] = `
       "valid": true,
     },
   ],
+  "geoDatum": "WGS-84",
+  "geoDatumAlgorithm": null,
+  "geoPressureAlgorithm": null,
   "gliderType": "",
   "hardwareVersion": null,
   "loggerId": "000",
@@ -579,6 +591,9 @@ exports[`IGCParser parse() 20211015.igc 1`] = `
       "valid": true,
     },
   ],
+  "geoDatum": "WGS-84",
+  "geoDatumAlgorithm": null,
+  "geoPressureAlgorithm": null,
   "gliderType": "Delta 2 S",
   "hardwareVersion": null,
   "loggerId": null,
@@ -634,6 +649,12 @@ exports[`IGCParser parseDateHeader() HFDTE -> 💥  1`] = `"Invalid DTE header a
 exports[`IGCParser parseDateHeader() HFDTE1234?6 -> 💥  1`] = `"Invalid DTE header at line 0: HFDTE1234?6"`;
 
 exports[`IGCParser parseDateHeader() HFDTEXXXXXX -> 💥  1`] = `"Invalid DTE header at line 0: HFDTEXXXXXX"`;
+
+exports[`IGCParser parseGeoDatum() [empty] -> 💥  1`] = `"Invalid FDT header at line 0: "`;
+
+exports[`IGCParser parseGeoDatumAlgorithm() [empty] -> 💥  1`] = `"Invalid ALG header at line 0: "`;
+
+exports[`IGCParser parseGeoPressureAlgorithm() [empty] -> 💥  1`] = `"Invalid ALP header at line 0: "`;
 
 exports[`IGCParser parseIJRecord() [empty] -> 💥  1`] = `"Invalid undefined record at line 0: "`;
 

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,9 @@ const RE_FTY_HEADER = /^H(\w)FTY(?:.{0,}?:(.*)|(.*))$/;
 const RE_RFW_HEADER = /^H(\w)RFW(?:.{0,}?:(.*)|(.*))$/;
 const RE_RHW_HEADER = /^H(\w)RHW(?:.{0,}?:(.*)|(.*))$/;
 const RE_TZN_HEADER = /^H(\w)TZN(?:.{0,}?:([-+]?[\d.]+))$/;
+const RE_DTM_HEADER = /^H(\w)DTM(?:.{0,}?:(.*)|(.*))$/;
+const RE_ALG_HEADER = /^H(\w)ALG(?:.{0,}?:(.*)|(.*))$/;
+const RE_ALP_HEADER = /^H(\w)ALP(?:.{0,}?:(.*)|(.*))$/;
 const RE_B = /^B(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})([NS])(\d{3})(\d{2})(\d{3})([EW])([AV])(-\d{4}|\d{5})(-\d{4}|\d{5})/;
 const RE_K = /^K(\d{2})(\d{2})(\d{2})/;
 const RE_IJ = /^[IJ](\d{2})(?:\d{2}\d{2}[A-Z]{3})+/;
@@ -52,6 +55,9 @@ declare namespace IGCParser {
     loggerType: string | null;
     firmwareVersion: string | null;
     hardwareVersion: string | null;
+    geoDatum: string | null;
+    geoDatumAlgorithm: string | null;
+    geoPressureAlgorithm: string | null;
 
     task: Task | null;
 
@@ -149,6 +155,9 @@ class IGCParser {
     loggerType: null,
     firmwareVersion: null,
     hardwareVersion: null,
+    geoDatum: null,
+    geoDatumAlgorithm: null,
+    geoPressureAlgorithm: null,
     task: null,
     fixes: [],
     dataRecords: [],
@@ -280,6 +289,12 @@ class IGCParser {
       this._result.firmwareVersion = this.parseFirmwareVersion(line);
     } else if (headerType === 'RHW') {
       this._result.hardwareVersion = this.parseHardwareVersion(line);
+    } else if (headerType === 'DTM') {
+      this._result.geoDatum = this.parseGeoDatum(line);
+    } else if (headerType === 'ALG') {
+      this._result.geoDatumAlgorithm = this.parseGeoDatumAlgorithm(line);
+    } else if (headerType === 'ALP') {
+      this._result.geoPressureAlgorithm = this.parseGeoPressureAlgorithm(line);
     }
   }
 
@@ -377,6 +392,18 @@ class IGCParser {
 
   private parseHardwareVersion(line: string): string {
     return this.parseTextHeader('RHW', RE_RHW_HEADER, line);
+  }
+
+  private parseGeoDatum(line: string): string {
+    return this.parseTextHeader('FDT', RE_DTM_HEADER, line);
+  }
+
+  private parseGeoDatumAlgorithm(line: string): string {
+    return this.parseTextHeader('ALG', RE_ALG_HEADER, line);
+  }
+
+  private parseGeoPressureAlgorithm(line: string): string {
+    return this.parseTextHeader('ALP', RE_ALP_HEADER, line);
   }
 
   private processTaskLine(line: string) {

--- a/test.ts
+++ b/test.ts
@@ -167,6 +167,36 @@ describe('IGCParser', () => {
         '2017-07-17T01:00:00.000Z',
       ]);
     });
+
+    it('handles GPS Datum FAI Sporting Code 2021 0.9.0 - 3.2.3 & 3.4', () => {
+      // Example data as of 3.4 - see fai.org
+      let result = IGCParser.parse([
+        'AVXX00026',
+        'HFDTEDATE:160816',
+        'HFPLTPILOTINCHARGE:Bloggs Bill',
+        'HFCM2CREW2:NIL',
+        'HFGTYGLIDERTYPE:NKN',
+        'HFGIDGLIDERID:NKN',
+        'HFDTMGPSDATUM:WGS84',
+        'HFRFWFIRMWAREVERSION:0.2-alpha',
+        'HFRHWHARDWAREVERSION:1.0',
+        'HFFTYFRTYPE:Zebra Instruments,Proto 1',
+        'HFGPSRECEIVER:UBLOX,NEO7,56,50000',
+        'HFPRSPRESSALTSENSOR:MEAS,MS5611,25907',
+        'HFALGALTGPS:GEO',
+        'HFALPALTPRESSURE:ISA',
+        'B1153555536248N00339528WA0050200475',
+        'B1154005536249N00339528WA0050300476',
+        'B1154105536249N00339528WA0050300477',
+        'B1154155536248N00339528WA0050300476',
+        'G5734B6437B7796F96460F5D8AAC8FD4F',
+        'G0B6401B0E19216179A25DAE23CD0487F',
+      ].join('\n'));
+
+      expect(result.geoDatum).toEqual('WGS84');
+      expect(result.geoDatumAlgorithm).toEqual('GEO');
+      expect(result.geoPressureAlgorithm).toEqual('ISA');
+    });
   });
 
   describeMethod('parseARecord', (test) => {
@@ -382,6 +412,26 @@ describe('IGCParser', () => {
     test.fail('');
     test.fail('I023638FXA');
     test.fail('I0136FXA38');
+  });
+
+  describeMethod('parseGeoDatum', (test) => {
+    test.pass('HFDTMGPSDATUM:WGS84', 'WGS84');
+    test.pass('HFDTM100GPSDATUM:WGS-1984', 'WGS-1984');
+    test.pass('HFDTM100GPSDATUM:WGS-84', 'WGS-84');
+
+    test.fail('');
+  });
+
+  describeMethod('parseGeoDatumAlgorithm', (test) => {
+    test.pass('HFALGALTGPS:GEO', 'GEO');
+
+    test.fail('');
+  });
+
+  describeMethod('parseGeoPressureAlgorithm', (test) => {
+    test.pass('HFALPALTPRESSURE:ISA', 'ISA');
+
+    test.fail('');
   });
 
   // Test Suite Generator


### PR DESCRIPTION
I'd like to submit following extension concerning GPS Datum headers

Existing HFDTM and new related headers HFALG and HFALP according to FAI Sporting Code 2021 0.9.0 - sections 3.2.3 & 3.4
in https://www.fai.org/sites/default/files/civl/documents/sporting_code_s7_h_-_civl_flight_recorder_specification_2021_v0.9.0.pdf

HFALGALTGPS:GEO
HFALPALTPRESSURE:ISA

Added parser logic and extended tests
Possibly more flavours of WGS84/WGS-84,... for the HFDTM100GPSDATUM header need to be accepted